### PR TITLE
perf(example): changing method name

### DIFF
--- a/src/SemanticReleaseExampleMessageService.js
+++ b/src/SemanticReleaseExampleMessageService.js
@@ -3,10 +3,10 @@
   Obviously, this is a pretty contrived example.
 */
 
-const getSemanticReleaseExampleMessage = () => ('This implements the semantic-release package. Find more information at https://github.com/semantic-release/semantic-release.');
+const getFirstSemanticReleaseExampleMessage = () => ('This implements the semantic-release package. Find more information at https://github.com/semantic-release/semantic-release.');
 const getAnotherSemanticReleaseExampleMessage = () => ('Another Semantic Release Example Message');
 
 export {
-  getSemanticReleaseExampleMessage,
+  getFirstSemanticReleaseExampleMessage,
   getAnotherSemanticReleaseExampleMessage,
 };

--- a/src/SemanticReleaseExampleMessageService.test.js
+++ b/src/SemanticReleaseExampleMessageService.test.js
@@ -1,9 +1,9 @@
-import { getSemanticReleaseExampleMessage, getAnotherSemanticReleaseExampleMessage } from './SemanticReleaseExampleMessageService';
+import { getFirstSemanticReleaseExampleMessage, getAnotherSemanticReleaseExampleMessage } from './SemanticReleaseExampleMessageService';
 
 describe('SemanticReleaseExampleMessageService', () => {
-  describe('#getSemanticReleaseExampleMessage', () => {
+  describe('#getFirstSemanticReleaseExampleMessage', () => {
     it('should return message', () => {
-      expect(getSemanticReleaseExampleMessage()).toEqual('This implements the semantic-release package. Find more information at https://github.com/semantic-release/semantic-release.');
+      expect(getFirstSemanticReleaseExampleMessage()).toEqual('This implements the semantic-release package. Find more information at https://github.com/semantic-release/semantic-release.');
     });
   });
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
-import { getSemanticReleaseExampleMessage, getAnotherSemanticReleaseExampleMessage } from './SemanticReleaseExampleMessageService';
+import { getFirstSemanticReleaseExampleMessage, getAnotherSemanticReleaseExampleMessage } from './SemanticReleaseExampleMessageService';
 
 export {
-  getSemanticReleaseExampleMessage,
+  getFirstSemanticReleaseExampleMessage,
   getAnotherSemanticReleaseExampleMessage,
 };


### PR DESCRIPTION
BREAKING CHANGE: The getSemanticReleaseExampleMessage has been renamed to getFirstSemanticReleaseExampleMessage